### PR TITLE
Fix predict.py don't work on CPU only torch version

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -39,7 +39,7 @@ def predict(inputs, theme):
 
     model_pos = '%s.pkl' % theme
     if os.path.exists(model_pos):
-        model.load_state_dict(torch.load(model_pos))
+        model.load_state_dict(torch.load(model_pos, map_location=lambda storage, location: storage))
 
     model.train(False)
 


### PR DESCRIPTION
Solution from:
https://discuss.pytorch.org/t/on-a-cpu-device-how-to-load-checkpoint-saved-on-gpu-device/349/3